### PR TITLE
forcing fixed versions for deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ sudo: false
 
 language: node_js
 node_js:
-   - "4"
+   - "node"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ sudo: false
 
 language: node_js
 node_js:
-   - "node"
+  - "node"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ sudo: false
 
 language: node_js
 node_js:
-  - "node"
+   - "4"

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "babel-cli": "6.6.4",
     "babel-core": "6.7.4",
     "babel-eslint": "6.0.2",
+    "babel-plugin-transform-es2015-modules-umd": "6.6.5",
     "babel-polyfill": "6.7.4",
     "babel-preset-es2015": "6.6.0",
     "babel-preset-react": "6.5.0",
@@ -56,6 +57,10 @@
     "react": "15.4.2",
     "react-dom": "15.4.2",
     "sinon": "1.17.3"
+  },
+  "peerDependencies": {
+    "react": "~0.14.8 || ^15.0.0",
+    "react-dom": "~0.14.8 || ^15.0.0"
   },
   "dependencies": {
     "babel-runtime": "6.6.1",

--- a/package.json
+++ b/package.json
@@ -34,38 +34,33 @@
   },
   "main": "./dist",
   "devDependencies": {
-    "babel-cli": "^6.6.4",
-    "babel-core": "^6.7.4",
-    "babel-eslint": "^6.0.2",
-    "babel-plugin-transform-es2015-modules-umd": "^6.6.5",
-    "babel-polyfill": "^6.7.4",
-    "babel-preset-es2015": "^6.6.0",
-    "babel-preset-react": "^6.5.0",
-    "babel-preset-stage-2": "^6.5.0",
-    "chai": "^3.5.0",
-    "enzyme": "^2.2.0",
+    "babel-cli": "6.6.4",
+    "babel-core": "6.7.4",
+    "babel-eslint": "6.0.2",
+    "babel-polyfill": "6.7.4",
+    "babel-preset-es2015": "6.6.0",
+    "babel-preset-react": "6.5.0",
+    "babel-preset-stage-2": "6.5.0",
+    "chai": "3.5.0",
+    "enzyme": "2.2.0",
     "eslint": "3.19.0",
     "eslint-config-airbnb": "14.1.0",
     "eslint-import-resolver-meteor": "0.3.4",
     "eslint-plugin-import": "2.2.0",
     "eslint-plugin-jsx-a11y": "4.0.0",
     "eslint-plugin-react": "6.10.3",
-    "jsdom": "^8.1.0",
-    "mocha": "^2.4.5",
-    "nodemon": "^1.9.1",
-    "react-addons-test-utils": "^15.0.0",
-    "react": "^15.0.0",
-    "react-dom": "^15.0.0",
-    "sinon": "^1.17.3"
-  },
-  "peerDependencies": {
-    "react": "~0.14.8 || ^15.0.0",
-    "react-dom": "~0.14.8 || ^15.0.0"
+    "jsdom": "8.1.0",
+    "mocha": "2.4.5",
+    "nodemon": "1.9.1",
+    "react-addons-test-utils": "15.0.0",
+    "react": "15.4.2",
+    "react-dom": "15.4.2",
+    "sinon": "1.17.3"
   },
   "dependencies": {
-    "babel-runtime": "^6.6.1",
-    "material-ui": "^0.17.1",
-    "react-tap-event-plugin": "^2.0.1",
-    "react-text-mask": "^4.1.0"
+    "babel-runtime": "6.6.1",
+    "material-ui": "0.17.1",
+    "react-tap-event-plugin": "2.0.1",
+    "react-text-mask": "4.1.0"
   }
 }


### PR DESCRIPTION
I'd rather use only fixed versions of dependencies.
It's safer in case of non backward compatible updates 